### PR TITLE
Adding Optimiser to encoding, change in Ranking

### DIFF
--- a/src/ZAP-HPO/config2vector.py
+++ b/src/ZAP-HPO/config2vector.py
@@ -22,7 +22,7 @@ _bool_hps = ["first_simple_model", "amsgrad", "nesterov"]
 _categorical_hps = ['simple_model_LR', 'simple_model_NuSVC', 'simple_model_RF',
        'simple_model_SVC', 'architecture_ResNet18',
        'architecture_efficientnetb0', 'architecture_efficientnetb1',
-       'architecture_efficientnetb2', 'scheduler_cosine', 'scheduler_plateau']
+       'architecture_efficientnetb2', 'scheduler_cosine', 'scheduler_plateau', 'optimiser_sgd','optimiser_adam', 'optimiser_adamw']
 
 N_AUGMENTATIONS = 15
 all_datasets = ['cifar100', 'cycle_gan_vangogh2photo', 'uc_merced', 'cifar10', 'cmaterdb_devanagari', 
@@ -41,7 +41,7 @@ HP_NAMES = ["cv_valid_ratio", "max_valid_count", "max_size", "train_info_sample"
 HP_NAMES = _numerical_hps+_categorical_hps
 
 ENCODE_ARCH = {'ResNet18':[1, 0, 0, 0],'efficientnetb0': [0, 1, 0, 0], 'efficientnetb1': [0, 0, 1, 0], 'efficientnetb2': [0, 0, 0, 1]}
-#ENCODE_OPTIM = {'SGD': [0, 0, 1], 'Adam': [0, 1, 0], 'AdamW': [1, 0, 0]}
+ENCODE_OPTIM = {'SGD': [0, 0, 1], 'Adam': [0, 1, 0], 'AdamW': [1, 0, 0]}
 ENCODE_SIMPLE_MODEL = {'SVC': [0, 0, 0, 1], 'NuSVC': [0, 1, 0, 0], 'RF': [0, 0, 1, 0], 'LR': [1, 0, 0, 0]}
 ENCODE_SCHED = {'plateau': [0, 1], 'cosine': [1, 0]}
 
@@ -97,7 +97,7 @@ def create_searchspace(path):
     hp_vector += ENCODE_ARCH[config['architecture']]  # 4
     hp_vector += ENCODE_SCHED[config['scheduler']]
 
-    # hp_vector += ENCODE_OPTIM[config['type']] #
+    hp_vector += ENCODE_OPTIM[config['type']]
     return dict(zip(HP_NAMES,hp_vector))
     hpo_X.append(hp_vector)
 

--- a/src/ZAP-HPO/config2vector.py
+++ b/src/ZAP-HPO/config2vector.py
@@ -1,60 +1,62 @@
 import os
 import sys
-sys.path.append(os.getcwd())
 import yaml
-import pickle
 from pathlib import Path
-
 import pandas as pd
-import numpy as np
-from sklearn.preprocessing import MinMaxScaler
 
-import json
+sys.path.append(os.getcwd())
 
 _numerical_hps = ['early_epoch', 'first_simple_model', 'max_inner_loop_ratio', 'min_lr',
-       'skip_valid_score_threshold', 'test_after_at_least_seconds',
-       'test_after_at_least_seconds_max', 'test_after_at_least_seconds_step',
-       'batch_size', 'cv_valid_ratio', 'max_size', 'max_valid_count',
-       'steps_per_epoch', 'train_info_sample', 'amsgrad', 'freeze_portion',
-       'lr', 'momentum', 'nesterov', 'warm_up_epoch', 'warmup_multiplier',
-       'wd']
+                  'skip_valid_score_threshold', 'test_after_at_least_seconds',
+                  'test_after_at_least_seconds_max', 'test_after_at_least_seconds_step',
+                  'batch_size', 'cv_valid_ratio', 'max_size', 'max_valid_count',
+                  'steps_per_epoch', 'train_info_sample', 'amsgrad', 'freeze_portion',
+                  'lr', 'momentum', 'nesterov', 'warm_up_epoch', 'warmup_multiplier',
+                  'wd']
 _bool_hps = ["first_simple_model", "amsgrad", "nesterov"]
 _categorical_hps = ['simple_model_LR', 'simple_model_NuSVC', 'simple_model_RF',
-       'simple_model_SVC', 'architecture_ResNet18',
-       'architecture_efficientnetb0', 'architecture_efficientnetb1',
-       'architecture_efficientnetb2', 'scheduler_cosine', 'scheduler_plateau', 'optimiser_sgd','optimiser_adam', 'optimiser_adamw']
+                    'simple_model_SVC', 'architecture_ResNet18',
+                    'architecture_efficientnetb0', 'architecture_efficientnetb1',
+                    'architecture_efficientnetb2', 'scheduler_cosine', 'scheduler_plateau', 'optimiser_sgd',
+                    'optimiser_adam', 'optimiser_adamw']
 
 N_AUGMENTATIONS = 15
-all_datasets = ['cifar100', 'cycle_gan_vangogh2photo', 'uc_merced', 'cifar10', 'cmaterdb_devanagari', 
-                'cmaterdb_bangla', 'mnist', 'horses_or_humans', 'kmnist', 'cycle_gan_horse2zebra', 'cycle_gan_facades', 
-                'cycle_gan_apple2orange', 'imagenet_resized_32x32', 'cycle_gan_maps', 'omniglot', 'imagenette', 'emnist_byclass', 
-                'svhn_cropped', 'colorectal_histology', 'coil100', 'stanford_dogs', 'rock_paper_scissors', 'tf_flowers', 
-                'cycle_gan_ukiyoe2photo', 'cassava', 'fashion_mnist', 'emnist_mnist', 'cmaterdb_telugu', 'malaria', 'eurosat_rgb', 
-                'emnist_balanced', 'cars196', 'cycle_gan_iphone2dslr_flower', 'cycle_gan_summer2winter_yosemite', 'cats_vs_dogs']
+all_datasets = ['cifar100', 'cycle_gan_vangogh2photo', 'uc_merced', 'cifar10', 'cmaterdb_devanagari',
+                'cmaterdb_bangla', 'mnist', 'horses_or_humans', 'kmnist', 'cycle_gan_horse2zebra', 'cycle_gan_facades',
+                'cycle_gan_apple2orange', 'imagenet_resized_32x32', 'cycle_gan_maps', 'omniglot', 'imagenette',
+                'emnist_byclass',
+                'svhn_cropped', 'colorectal_histology', 'coil100', 'stanford_dogs', 'rock_paper_scissors', 'tf_flowers',
+                'cycle_gan_ukiyoe2photo', 'cassava', 'fashion_mnist', 'emnist_mnist', 'cmaterdb_telugu', 'malaria',
+                'eurosat_rgb',
+                'emnist_balanced', 'cars196', 'cycle_gan_iphone2dslr_flower', 'cycle_gan_summer2winter_yosemite',
+                'cats_vs_dogs']
 
-'''
-HP_NAMES = ["cv_valid_ratio", "max_valid_count", "max_size", "train_info_sample", "steps_per_epoch", "early_epoch", "skip_valid_score_threshold", 
-            "test_after_at_least_seconds", "test_after_at_least_seconds_max", "test_after_at_least_seconds_step", "max_inner_loop_ratio", "batch_size", 
-            "lr", "min_lr", "architecture", "wd", "momentum", "optimizer", "nesterov", "amsgrad", "scheduler", "freeze_portion", "warmup_multiplier", 
-            "warm_up_epoch", "first_simple_model", "simple_model"]
-'''
-HP_NAMES = _numerical_hps+_categorical_hps
+'''HP_NAMES = ["cv_valid_ratio", "max_valid_count", "max_size", "train_info_sample", "steps_per_epoch", 
+"early_epoch", "skip_valid_score_threshold", "test_after_at_least_seconds", "test_after_at_least_seconds_max", 
+"test_after_at_least_seconds_step", "max_inner_loop_ratio", "batch_size", "lr", "min_lr", "architecture", "wd", 
+"momentum", "optimizer", "nesterov", "amsgrad", "scheduler", "freeze_portion", "warmup_multiplier", "warm_up_epoch", 
+"first_simple_model", "simple_model"] '''
+HP_NAMES = _numerical_hps + _categorical_hps
 
-ENCODE_ARCH = {'ResNet18':[1, 0, 0, 0],'efficientnetb0': [0, 1, 0, 0], 'efficientnetb1': [0, 0, 1, 0], 'efficientnetb2': [0, 0, 0, 1]}
+ENCODE_ARCH = {'ResNet18': [1, 0, 0, 0], 'efficientnetb0': [0, 1, 0, 0], 'efficientnetb1': [0, 0, 1, 0],
+               'efficientnetb2': [0, 0, 0, 1]}
 ENCODE_OPTIM = {'SGD': [0, 0, 1], 'Adam': [0, 1, 0], 'AdamW': [1, 0, 0]}
 ENCODE_SIMPLE_MODEL = {'SVC': [0, 0, 0, 1], 'NuSVC': [0, 1, 0, 0], 'RF': [0, 0, 1, 0], 'LR': [1, 0, 0, 0]}
 ENCODE_SCHED = {'plateau': [0, 1], 'cosine': [1, 0]}
 
-def get_config_response(config_dir = Path(__file__).parents[6] / "data/meta_dataset/configs" / "kakaobrain_optimized_per_icgen_augmentation", 
-                        response_dir = Path(__file__).parents[6] / "data/meta_dataset/perf_matrix.csv"):
-    config_paths = [os.path.join(config_dir, str(n), dataset_name)+'.yaml' for dataset_name in all_datasets for n in range(N_AUGMENTATIONS)]
-    response_ids = [str(n)+'-'+dataset_name for dataset_name in all_datasets for n in range(N_AUGMENTATIONS)]
-    response = pd.read_csv(response_dir, index_col = 0)
+
+def get_config_response(config_dir=Path(__file__).parents[
+                                       6] / "data/meta_dataset/configs" / "kakaobrain_optimized_per_icgen_augmentation",
+                        response_dir=Path(__file__).parents[6] / "data/meta_dataset/perf_matrix.csv"):
+    config_paths = [os.path.join(config_dir, str(n), dataset_name) + '.yaml' for dataset_name in all_datasets for n in
+                    range(N_AUGMENTATIONS)]
+    response_ids = [str(n) + '-' + dataset_name for dataset_name in all_datasets for n in range(N_AUGMENTATIONS)]
+    response = pd.read_csv(response_dir, index_col=0)
 
     return config_paths, response_ids, response
 
+
 def create_searchspace(path):
-    hpo_X = []
     with open(path) as stream:
         model_config = yaml.safe_load(stream)
 
@@ -98,20 +100,13 @@ def create_searchspace(path):
     hp_vector += ENCODE_SCHED[config['scheduler']]
 
     hp_vector += ENCODE_OPTIM[config['type']]
-    return dict(zip(HP_NAMES,hp_vector))
-    hpo_X.append(hp_vector)
+    return dict(zip(HP_NAMES, hp_vector))
 
-    #hpo_X = MinMaxScaler().fit_transform(hpo_X) 
-    
-    '''
-    hpo_dict = dict()
-    for idx, _id in enumerate(response_ids):
-        hpo_dict[_id] = {'CONFIG': hpo_X[idx],
-                         'RESPONSE': np.expand_dims(np.array([response.loc[_id2, _id] for _id2 in response_ids]), axis = 1),
-                         }
-    // Not using it right now
-    with open(os.path.join("results/config_vectors.json"), "w") as f:
-        json.dump(hpo_dict, f)
-    '''
+    # hpo_X = MinMaxScaler().fit_transform(hpo_X)
+
+    '''hpo_dict = dict() for idx, _id in enumerate(response_ids): hpo_dict[_id] = {'CONFIG': hpo_X[idx], 'RESPONSE': 
+    np.expand_dims(np.array([response.loc[_id2, _id] for _id2 in response_ids]), axis = 1), } // Not using it right 
+    now with open(os.path.join("results/config_vectors.json"), "w") as f: json.dump(hpo_dict, f)
 
     return hpo_X
+    '''

--- a/src/ZAP-HPO/create_data_m.py
+++ b/src/ZAP-HPO/create_data_m.py
@@ -29,7 +29,7 @@ def construct_csv(meta_feat, perf_mat, incumbent_list, save_as):
             accuracy_list = perf_mat.loc[[new_row['dataset']]]
             accuracy = accuracy_list[incumbent].values.item()
             # -1 because rank sets the lowest to 1 and data_m.csv uses 0. False so highest score is ranked 1st
-            ranks = accuracy_list.rank(axis=1, ascending=False, method='first') - 1
+            ranks = accuracy_list.rank(axis=1, ascending=False, method='max') - 1
             # value returns as a series
             new_row['accuracy'] = accuracy
             # open the relevant yaml from the incumbent, (replace to get paths right)

--- a/src/ZAP-HPO/create_data_m.py
+++ b/src/ZAP-HPO/create_data_m.py
@@ -24,9 +24,9 @@ def construct_csv(meta_feat, perf_mat, incumbent_list, save_as):
     # Can it be faster??
     for features in tqdm.tqdm(meta_dict):
         # accuracy for testing on features['dataset] by incumbent eg  accuracy.loc[[incumbent]]
+        accuracy_list = perf_mat.loc[[features['dataset']]]
         for incumbent in incumbent_list:
             new_row = {**features, 'incumbent_of': incumbent}
-            accuracy_list = perf_mat.loc[[new_row['dataset']]]
             accuracy = accuracy_list[incumbent].values.item()
             # -1 because rank sets the lowest to 1 and data_m.csv uses 0. False so highest score is ranked 1st
             ranks = accuracy_list.rank(axis=1, ascending=False, method='max') - 1

--- a/src/ZAP-HPO/loader.py
+++ b/src/ZAP-HPO/loader.py
@@ -32,7 +32,7 @@ class TestDatabase(Dataset):
   def __init__(self, data_path, loo, mean_input, std_input, mean_output, std_output,split_type="cv", use_meta=True):
     
     # read data
-    data =pd.read_csv(os.path.join(data_path,"data_m.csv"),header=0)
+    data =pd.read_csv(os.path.join(data_path,"data_m_gen.csv"),header=0)
     if split_type=="loo":
         with open(os.path.join(data_path,"cls_names.pkl"),"rb") as f:
             self.cls = pickle.load(f)
@@ -125,7 +125,7 @@ class TrainDatabaseCV(TrainDatabase):
     self.rng = np.random.RandomState(0)
     self.valid_rng = np.random.RandomState(0)
     # read data
-    data = pd.read_csv(os.path.join(data_path,"data_m.csv"),header=0)
+    data = pd.read_csv(os.path.join(data_path,"data_m_gen.csv"),header=0)
     cv_folds = pd.read_csv(os.path.join(data_path,"cv_folds.csv"),header=0)
     cls = list(cv_folds[~cv_folds["fold"].isin([cv])]["Unnamed: 0"].apply(lambda x: x.split("-")[1]).unique())
     valid_cls_names = self.valid_rng.choice(cls,replace=False,size=3)
@@ -210,7 +210,7 @@ class TrainDatabaseCVPlusLoo(TrainDatabase):
     self.rng2 = np.random.RandomState(0)
     self.valid_rng = np.random.RandomState(0)
     # read data
-    data = pd.read_csv(os.path.join(data_path,"data_m.csv"),header=0)
+    data = pd.read_csv(os.path.join(data_path,"data_m_gen.csv"),header=0)
     cv_folds = pd.read_csv(os.path.join(data_path,"cv_folds.csv"),header=0)
     with open(os.path.join(data_path,"cls_names.pkl"),"rb") as f:
         self.cls = pickle.load(f)

--- a/src/ZAP-HPO/runner.py
+++ b/src/ZAP-HPO/runner.py
@@ -64,7 +64,7 @@ class ModelRunner:
         self.max_corr_dict = {'rank@1': np.inf, 'epoch': -1, "ndcg@5":-1, "ndcg@10":-1, "ndcg@20":-1}
         cs = self.get_configspace(self.seed)
         config = cs.sample_configuration()
-        self.model = batch_mlp(d_in=39 if self.use_meta else 35,output_sizes=config["num_hidden_layers"]*[config["num_hidden_units"]]+[1],
+        self.model = batch_mlp(d_in=42 if self.use_meta else 38,output_sizes=config["num_hidden_layers"]*[config["num_hidden_units"]]+[1],
                                dropout=config["dropout_rate"])
         self.model.to(self.device)
         config["lr"]=1e-3


### PR DESCRIPTION
### Adding Optimiser choice to vector encoding
Encoding now 42 params with meta features included, 38 w/o.
- Added 3 keys to HP_NAMES to encode which optimiser is used. 
- MLP size used in ZAP-HPO also changed.
- Name of the data file the mlp reads from in TrainDatabaseCV, TrainDatabaseCVPlusLoo,TestDatabase now data_m_gen.csv

### Ranking
Accuracies of two pipelines in the performance matrix can be equal for a given test dataset but the rank assigned to them is unique as per data_m.csv . 
- changed ranking order so equal accuracy pipelines have equal ranks. 

### Updated CSV file
- added